### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -5,9 +5,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = linters_with_defaults(
-  line_length_linter = line_length_linter(1000),
-  object_name_linter = object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = linters_with_defaults(
+    line_length_linter = line_length_linter(1000),
+    object_name_linter = object_name_linter(regexes = ".*")
+  )
 )
 
 lintr::lint_package()


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)